### PR TITLE
Fix alignCast error on aarch64-linux

### DIFF
--- a/src/containers.zig
+++ b/src/containers.zig
@@ -14,7 +14,7 @@ const Callbacks = struct {
     getSize: *const fn (data: usize) Size,
     computingPreferredSize: bool,
     availableSize: ?Size = null,
-    layoutConfig: [16]u8,
+    layoutConfig: [16]u8 align(4),
 
     pub fn getLayoutConfig(self: Callbacks, comptime T: type) T {
         comptime std.debug.assert(@sizeOf(T) <= 16);


### PR DESCRIPTION
- Tested on a pinephone running postmarketOS

The alignment of [16]u8 on aarch64 was apparently 1, causing the alignCast to fail. Setting the align to 4 solves the issue.