### PR TITLE
Update to the new build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -105,7 +105,6 @@ pub fn build(b: *std.Build) !void {
             else
                 b.addExecutable(.{ .name = name, .root_source_file = programPath, .target = target, .optimize = optimize });
             try install(exe, .{});
-            exe.install();
 
             const install_step = b.addInstallArtifact(exe);
             const working = blk: {

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const http = @import("deps.zig").imports.apple_pie;
 const install = @import("build_capy.zig").install;
+const installBuild = @import("build_capy.zig").installBuild;
 const FileSource = std.build.FileSource;
 
 /// Step used to run a web server
@@ -104,6 +105,7 @@ pub fn build(b: *std.Build) !void {
             else
                 b.addExecutable(.{ .name = name, .root_source_file = programPath, .target = target, .optimize = optimize });
             try install(exe, .{});
+            exe.install();
 
             const install_step = b.addInstallArtifact(exe);
             const working = blk: {

--- a/build.zig
+++ b/build.zig
@@ -170,12 +170,14 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Run unit tests and also generate the documentation");
     test_step.dependOn(&tests.step);
 
-    // const coverage_tests = b.addTest("src/main.zig");
-    // coverage_tests.setTarget(target);
-    // coverage_tests.setBuildMode(mode);
-    // coverage_tests.exec_cmd_args = &.{ "kcov", "--clean", "--include-pattern=src/", "kcov-output", null };
-    // try install(coverage_tests, .{});
+    const coverage_tests = b.addTest(.{
+        .root_source_file = FileSource.relative("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    coverage_tests.exec_cmd_args = &.{ "kcov", "--clean", "--include-pattern=src/", "kcov-output", null };
+    try install(coverage_tests, .{});
 
-    // const cov_step = b.step("coverage", "Perform code coverage of unit tests. This requires 'kcov' to be installed.");
-    // cov_step.dependOn(&coverage_tests.step);
+    const cov_step = b.step("coverage", "Perform code coverage of unit tests. This requires 'kcov' to be installed.");
+    cov_step.dependOn(&coverage_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const http = @import("deps.zig").imports.apple_pie;
 const install = @import("build_capy.zig").install;
+const FileSource = std.build.FileSource;
 
 /// Step used to run a web server
 const WebServerStep = struct {
@@ -76,9 +77,9 @@ const WebServerStep = struct {
     }
 };
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
     var examplesDir = try std.fs.cwd().openIterableDir("examples", .{});
     defer examplesDir.close();
@@ -96,14 +97,12 @@ pub fn build(b: *std.build.Builder) !void {
             defer b.allocator.free(name);
 
             // it is not freed as the path is used later for building
-            const programPath = b.pathJoin(&.{ "examples", entry.path });
+            const programPath = FileSource.relative(b.pathJoin(&.{ "examples", entry.path }));
 
             const exe: *std.build.LibExeObjStep = if (target.toTarget().isWasm())
-                b.addSharedLibrary(name, programPath, .unversioned)
+                b.addSharedLibrary(.{ .name = name, .root_source_file = programPath, .target = target, .optimize = optimize })
             else
-                b.addExecutable(name, programPath);
-            exe.setTarget(target);
-            exe.setBuildMode(mode);
+                b.addExecutable(.{ .name = name, .root_source_file = programPath, .target = target, .optimize = optimize });
             try install(exe, .{});
 
             const install_step = b.addInstallArtifact(exe);
@@ -140,9 +139,13 @@ pub fn build(b: *std.build.Builder) !void {
         }
     }
 
-    const lib = b.addSharedLibrary("capy", "src/c_api.zig", b.version(0, 3, 0));
-    lib.setTarget(target);
-    lib.setBuildMode(mode);
+    const lib = b.addSharedLibrary(.{
+        .name = "capy",
+        .root_source_file = FileSource.relative("src/c_api.zig"),
+        .version = std.builtin.Version{ .major = 0, .minor = 3, .patch = 0 },
+        .target = target,
+        .optimize = optimize,
+    });
     lib.linkLibC();
     try install(lib, .{});
     // lib.emit_h = true;
@@ -154,21 +157,23 @@ pub fn build(b: *std.build.Builder) !void {
     const buildc_step = b.step("shared", "Build capy as a shared library (with C ABI)");
     buildc_step.dependOn(&lib.install_step.?.step);
 
-    const tests = b.addTest("src/main.zig");
-    tests.setTarget(target);
-    tests.setBuildMode(mode);
+    const tests = b.addTest(.{
+        .root_source_file = FileSource.relative("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     // tests.emit_docs = .emit;
     try install(tests, .{});
 
     const test_step = b.step("test", "Run unit tests and also generate the documentation");
     test_step.dependOn(&tests.step);
 
-    const coverage_tests = b.addTest("src/main.zig");
-    coverage_tests.setTarget(target);
-    coverage_tests.setBuildMode(mode);
-    coverage_tests.exec_cmd_args = &.{ "kcov", "--clean", "--include-pattern=src/", "kcov-output", null };
-    try install(coverage_tests, .{});
+    // const coverage_tests = b.addTest("src/main.zig");
+    // coverage_tests.setTarget(target);
+    // coverage_tests.setBuildMode(mode);
+    // coverage_tests.exec_cmd_args = &.{ "kcov", "--clean", "--include-pattern=src/", "kcov-output", null };
+    // try install(coverage_tests, .{});
 
-    const cov_step = b.step("coverage", "Perform code coverage of unit tests. This requires 'kcov' to be installed.");
-    cov_step.dependOn(&coverage_tests.step);
+    // const cov_step = b.step("coverage", "Perform code coverage of unit tests. This requires 'kcov' to be installed.");
+    // cov_step.dependOn(&coverage_tests.step);
 }

--- a/build_capy.zig
+++ b/build_capy.zig
@@ -1,11 +1,5 @@
 const std = @import("std");
 const AndroidSdk = @import("android/Sdk.zig");
-//const build_zelda = @import("vendor/zelda/build.zig");
-const zig_libressl = struct {};
-// const zig_libressl = if (@import("builtin").os.tag == .windows)
-//     struct {} // TODO: fix
-// else
-//     @import("vendor/zelda/zig-libressl/build.zig");
 
 pub const CapyBuildOptions = struct {
     android: AndroidOptions = .{},
@@ -13,44 +7,39 @@ pub const CapyBuildOptions = struct {
     pub const AndroidOptions = struct {
         // As of 2022, 95% of Android devices use Android 8 (Oreo) or higher
         version: AndroidSdk.AndroidVersion = .android8,
-        // TODO: implement sdk downloading
+        // TODO: implement sdk download
         download_sdk_automatically: bool = true,
     };
 };
 
 pub fn install(step: *std.build.LibExeObjStep, options: CapyBuildOptions) !void {
+    _ = options;
+
     const prefix = comptime std.fs.path.dirname(@src().file).? ++ std.fs.path.sep_str;
+    const build = step.builder;
     step.subsystem = .Native;
 
-    const zigimg = std.build.Pkg{
+    build.addModule(.{
         .name = "zigimg",
-        .source = std.build.FileSource{ .path = prefix ++ "/vendor/zigimg/zigimg.zig" },
-    };
+        .source_file = std.build.FileSource{ .path = prefix ++ "/vendor/zigimg/zigimg.zig" },
+    });
 
-    // const zelda = build_zelda.pkgs.zelda;
-    // const use_system_libressl = @import("builtin").os.tag == .windows;
-    // if ((comptime @import("builtin").os.tag != .windows) and step.target.getOsTag() != .freestanding and step.target.getOsTag() != .windows and false) {
-    //     try zig_libressl.useLibreSslForStep(
-    //         step.builder,
-    //         step.target,
-    //         .ReleaseSafe,
-    //         prefix ++ "/vendor/zelda/zig-libressl/libressl",
-    //         step,
-    //         use_system_libressl,
-    //     );
-    // }
-
-    const capy = std.build.Pkg{
+    build.addModule(.{
         .name = "capy",
-        .source = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
-        //.dependencies = &[_]std.build.Pkg{ zigimg, zelda },
-        .dependencies = &[_]std.build.Pkg{zigimg},
-    };
-    if (!step.target.toTarget().isAndroid()) step.addPackage(capy);
+        .source_file = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
+    });
+
+    // const capy = std.build.Pkg{
+    //     .name = "capy",
+    //     .source = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
+    //     //.dependencies = &[_]std.build.Pkg{ zigimg, zelda },
+    //     .dependencies = &[_]std.build.Pkg{zigimg},
+    // };
+    //if (!step.target.toTarget().isAndroid()) step.addPackage(capy);
 
     switch (step.target.getOsTag()) {
         .windows => {
-            switch (step.build_mode) {
+            switch (step.optimize) {
                 .Debug => step.subsystem = .Console,
                 else => step.subsystem = .Windows,
             }
@@ -85,95 +74,95 @@ pub fn install(step: *std.build.LibExeObjStep, options: CapyBuildOptions) !void 
         },
         .linux, .freebsd => {
             if (step.target.toTarget().isAndroid()) {
-                // TODO: automatically download the SDK and NDK and build tools?
-                // TODO: download Material components by parsing Maven?
-                const sdk = AndroidSdk.init(step.builder, null, .{});
-                const mode = step.build_mode;
+                // // TODO: automatically download the SDK and NDK and build tools?
+                // // TODO: download Material components by parsing Maven?
+                // const sdk = AndroidSdk.init(step.builder, null, .{});
+                // const mode = step.build_mode;
 
-                // Provide some KeyStore structure so we can sign our app.
-                // Recommendation: Don't hardcore your password here, everyone can read it.
-                // At least not for your production keystore ;)
-                const key_store = AndroidSdk.KeyStore{
-                    .file = ".build_config/android.keystore",
-                    .alias = "default",
-                    .password = "ziguana",
-                };
+                // // Provide some KeyStore structure so we can sign our app.
+                // // Recommendation: Don't hardcore your password here, everyone can read it.
+                // // At least not for your production keystore ;)
+                // const key_store = AndroidSdk.KeyStore{
+                //     .file = ".build_config/android.keystore",
+                //     .alias = "default",
+                //     .password = "ziguana",
+                // };
 
-                var libraries = std.ArrayList([]const u8).init(step.builder.allocator);
-                try libraries.append("GLESv2");
-                try libraries.append("EGL");
-                try libraries.append("android");
-                try libraries.append("log");
+                // var libraries = std.ArrayList([]const u8).init(step.builder.allocator);
+                // try libraries.append("GLESv2");
+                // try libraries.append("EGL");
+                // try libraries.append("android");
+                // try libraries.append("log");
 
-                const config = AndroidSdk.AppConfig{
-                    .target_version = options.android.version,
-                    // This is displayed to the user
-                    .display_name = "Capy Example",
-                    // This is used internally for ... things?
-                    .app_name = "capyui_example",
-                    // This is required for the APK name. This identifies your app, android will associate
-                    // your signing key with this identifier and will prevent updates if the key changes.
-                    .package_name = "io.capyui.example",
-                    // This is a set of resources. It should at least contain a "mipmap/icon.png" resource that
-                    // will provide the application icon.
-                    .resources = &[_]AndroidSdk.Resource{
-                        .{ .path = "mipmap/icon.png", .content = .{ .path = "android/default_icon.png" } },
-                    },
-                    .aaudio = false,
-                    .opensl = false,
-                    // This is a list of android permissions. Check out the documentation to figure out which you need.
-                    .permissions = &[_][]const u8{
-                        "android.permission.SET_RELEASE_APP",
-                        //"android.permission.RECORD_AUDIO",
-                    },
-                    // This is a list of native android apis to link against.
-                    .libraries = libraries.items,
-                    //.fullscreen = true,
-                };
+                // const config = AndroidSdk.AppConfig{
+                //     .target_version = options.android.version,
+                //     // This is displayed to the user
+                //     .display_name = "Capy Example",
+                //     // This is used internally for ... things?
+                //     .app_name = "capyui_example",
+                //     // This is required for the APK name. This identifies your app, android will associate
+                //     // your signing key with this identifier and will prevent updates if the key changes.
+                //     .package_name = "io.capyui.example",
+                //     // This is a set of resources. It should at least contain a "mipmap/icon.png" resource that
+                //     // will provide the application icon.
+                //     .resources = &[_]AndroidSdk.Resource{
+                //         .{ .path = "mipmap/icon.png", .content = .{ .path = "android/default_icon.png" } },
+                //     },
+                //     .aaudio = false,
+                //     .opensl = false,
+                //     // This is a list of android permissions. Check out the documentation to figure out which you need.
+                //     .permissions = &[_][]const u8{
+                //         "android.permission.SET_RELEASE_APP",
+                //         //"android.permission.RECORD_AUDIO",
+                //     },
+                //     // This is a list of native android apis to link against.
+                //     .libraries = libraries.items,
+                //     //.fullscreen = true,
+                // };
 
-                const app = sdk.createApp(
-                    "zig-out/capy-app.apk",
-                    step.root_src.?.getPath(step.builder),
-                    "android/classes.dex",
-                    config,
-                    mode,
-                    .{
-                        .aarch64 = true,
-                        .arm = false,
-                        .x86_64 = false,
-                        .x86 = false,
-                    }, // default targets
-                    key_store,
-                );
+                // const app = sdk.createApp(
+                //     "zig-out/capy-app.apk",
+                //     step.root_src.?.getPath(step.builder),
+                //     "android/classes.dex",
+                //     config,
+                //     mode,
+                //     .{
+                //         .aarch64 = true,
+                //         .arm = false,
+                //         .x86_64 = false,
+                //         .x86 = false,
+                //     }, // default targets
+                //     key_store,
+                // );
 
-                const capy_android = std.build.Pkg{
-                    .name = "capy",
-                    .source = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
-                    .dependencies = &[_]std.build.Pkg{ zigimg, app.getAndroidPackage("android") },
-                };
-                for (app.libraries) |exe| {
-                    // Provide the "android" package in each executable we build
-                    exe.addPackage(capy_android);
-                }
-                step.addPackage(capy_android);
-                step.export_symbol_names = &.{"ANativeActivity_onCreate"};
+                // const capy_android = std.build.Pkg{
+                //     .name = "capy",
+                //     .source = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
+                //     .dependencies = &[_]std.build.Pkg{ zigimg, app.getAndroidPackage("android") },
+                // };
+                // for (app.libraries) |exe| {
+                //     // Provide the "android" package in each executable we build
+                //     exe.addPackage(capy_android);
+                // }
+                // step.addPackage(capy_android);
+                // step.export_symbol_names = &.{"ANativeActivity_onCreate"};
 
-                // Make the app build when we invoke "zig build" or "zig build install"
-                // TODO: only invoke keystore if .build_config/android.keystore doesn't exist
-                // When doing take environment variables or prompt if they're unavailable
-                //step.step.dependOn(sdk.initKeystore(key_store, .{}));
-                step.step.dependOn(app.final_step);
+                // // Make the app build when we invoke "zig build" or "zig build install"
+                // // TODO: only invoke keystore if .build_config/android.keystore doesn't exist
+                // // When doing take environment variables or prompt if they're unavailable
+                // //step.step.dependOn(sdk.initKeystore(key_store, .{}));
+                // step.step.dependOn(app.final_step);
 
-                //const b = step.builder;
-                // const keystore_step = b.step("keystore", "Initialize a fresh debug keystore");
-                // const push_step = b.step("push", "Push the app to a connected android device");
-                // const run_step = b.step("run", "Run the app on a connected android device");
+                // //const b = step.builder;
+                // // const keystore_step = b.step("keystore", "Initialize a fresh debug keystore");
+                // // const push_step = b.step("push", "Push the app to a connected android device");
+                // // const run_step = b.step("run", "Run the app on a connected android device");
 
-                // keystore_step.dependOn(sdk.initKeystore(key_store, .{}));
-                // push_step.dependOn(app.install());
-                // run_step.dependOn(app.run());
-                step.step.dependOn(app.install());
-                step.step.dependOn(app.run());
+                // // keystore_step.dependOn(sdk.initKeystore(key_store, .{}));
+                // // push_step.dependOn(app.install());
+                // // run_step.dependOn(app.run());
+                // step.step.dependOn(app.install());
+                // step.step.dependOn(app.run());
             } else {
                 step.linkLibC();
                 step.linkSystemLibrary("gtk+-3.0");
@@ -184,7 +173,7 @@ pub fn install(step: *std.build.LibExeObjStep, options: CapyBuildOptions) !void 
                 // Things like the image reader require more stack than given by default
                 // TODO: remove once ziglang/zig#12589 is merged
                 step.stack_size = std.math.max(step.stack_size orelse 0, 256 * 1024);
-                if (step.build_mode == .ReleaseSmall) {
+                if (step.optimize == .ReleaseSmall) {
                     step.strip = true;
                 }
             } else {

--- a/build_capy.zig
+++ b/build_capy.zig
@@ -12,21 +12,17 @@ pub const CapyBuildOptions = struct {
     };
 };
 
-pub fn install(step: *std.build.LibExeObjStep, options: CapyBuildOptions) !void {
+pub fn install(step: *std.Build.CompileStep, options: CapyBuildOptions) !void {
     _ = options;
-
     const prefix = comptime std.fs.path.dirname(@src().file).? ++ std.fs.path.sep_str;
-    const build = step.builder;
     step.subsystem = .Native;
 
-    build.addModule(.{
-        .name = "zigimg",
-        .source_file = std.build.FileSource{ .path = prefix ++ "/vendor/zigimg/zigimg.zig" },
+    step.addAnonymousModule("zigimg", .{
+        .source_file = .{ .path = prefix ++ "/vendor/zigimg/zigimg.zig" },
     });
 
-    build.addModule(.{
-        .name = "capy",
-        .source_file = std.build.FileSource{ .path = prefix ++ "/src/main.zig" },
+    step.addAnonymousModule("capy", .{
+        .source_file = .{ .path = prefix ++ "/src/main.zig" },
     });
 
     // const capy = std.build.Pkg{

--- a/build_capy.zig
+++ b/build_capy.zig
@@ -15,14 +15,18 @@ pub const CapyBuildOptions = struct {
 pub fn install(step: *std.Build.CompileStep, options: CapyBuildOptions) !void {
     _ = options;
     const prefix = comptime std.fs.path.dirname(@src().file).? ++ std.fs.path.sep_str;
+    const b = step.builder;
     step.subsystem = .Native;
 
-    step.addAnonymousModule("zigimg", .{
+    const zigimg = b.createModule(.{
         .source_file = .{ .path = prefix ++ "/vendor/zigimg/zigimg.zig" },
     });
 
     step.addAnonymousModule("capy", .{
         .source_file = .{ .path = prefix ++ "/src/main.zig" },
+        .dependencies = &.{
+            .{ .name = "zigimg", .module = zigimg }
+        }
     });
 
     // const capy = std.build.Pkg{
@@ -50,7 +54,6 @@ pub fn install(step: *std.Build.CompileStep, options: CapyBuildOptions) !void {
         },
         .macos => {
             if (@import("builtin").os.tag != .macos) {
-                const b = step.builder;
                 const sdk_root_dir = b.pathFromRoot("macos-sdk/");
                 const sdk_framework_dir = std.fs.path.join(b.allocator, &.{ sdk_root_dir, "System/Library/Frameworks" }) catch unreachable;
                 const sdk_include_dir = std.fs.path.join(b.allocator, &.{ sdk_root_dir, "usr/include" }) catch unreachable;

--- a/examples/slide-viewer.zig
+++ b/examples/slide-viewer.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const capy = @import("capy");
+pub usingnamespace capy.cross_platform;
+
+pub fn main() !void {
+    try capy.backend.init();
+
+    const imageData = try capy.ImageData.fromBuffer(capy.internal.lasting_allocator, @embedFile("ziglogo.png"));
+
+    var window = try capy.Window.init();
+    try window.set(capy.Stack(.{
+        capy.Rect(.{ .color = capy.Color.comptimeFromString("#2D2D2D") }),
+        capy.Image(.{ .data = imageData }),
+        capy.Column(.{}, .{
+            capy.Spacing(),
+            capy.Row(.{}, .{
+                capy.Button(.{ .label = "Previous", .enabled = false }), // TODO: capy Icon left arrow / previous + tooltip
+                capy.Button(.{ .label = "Next", .enabled = false }), // TODO: capy Icon right arrow / next + tooltip
+                capy.Expanded(capy.Label(.{ .text = "TODO: slider" })),
+                capy.Button(.{ .label = "Fullscreen" }), // TODO: capy Icon fullscreen + tooltip
+            }),
+        }),
+    }));
+
+    window.setTitle("Slide Viewer");
+    window.resize(800, 600);
+    window.show();
+    capy.runEventLoop();
+}

--- a/src/label.zig
+++ b/src/label.zig
@@ -49,7 +49,7 @@ pub const Label_Impl = struct {
         if (self.peer) |peer| {
             return peer.getPreferredSize();
         } else {
-            const len = std.mem.len(self.text.get());
+            const len = self.text.get().len;
             return Size{ .width = @intCast(u32, 10 * len), .height = 40.0 };
         }
     }

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -100,6 +100,7 @@ const TestType = struct {
         .preferredSizeFn = undefined,
         .setWidgetFn = undefined,
         .getParentFn = undefined,
+        .isDisplayedFn = undefined,
     };
 };
 


### PR DESCRIPTION
Latest Zig `master` versions introduced tons of breaking changes in the form of a new build system.  
This branch gets Capy going, at least barely, there's still the entirety of ZigAndroidTemplate's `Sdk.zig` which needs to be updated, so for now the Android backend is disabled (alongside the WASM backend).