### PR TITLE
attempt to fix `error: switch must handle all possibilities` in gtk backend

### DIFF
--- a/src/backends/gtk/backend.zig
+++ b/src/backends/gtk/backend.zig
@@ -353,6 +353,7 @@ pub fn Events(comptime T: type) type {
                 .Resize => data.resizeHandler = cb,
                 .KeyType => data.keyTypeHandler = cb,
                 .KeyPress => data.keyPressHandler = cb,
+                .PropertyChange => data.propertyChangeHandler = cb,
             }
         }
 


### PR DESCRIPTION
when i tried `capy` with `gtk` backend i got this error ( with latest zig version )

```
.zigmod/deps/git/github.com/capy-ui/capy/src/backends/gtk/backend.zig:346:13: error: switch must handle all possibilities
            switch (eType) {
            ^~~~~~
.zigmod/deps/git/github.com/capy-ui/capy/src/backends/shared.zig:17:5: note: unhandled enumeration value: 'PropertyChange'
    PropertyChange,
    ^~~~~~~~~~~~~~
.zigmod/deps/git/github.com/capy-ui/capy/src/backends/shared.zig:5:30: note: enum 'backends.shared.BackendEventType' declared here
pub const BackendEventType = enum {
                             ^~~~
.zigmod/deps/git/github.com/capy-ui/capy/src/internal.zig:558:40: note: called from here
            try self.peer.?.setCallback(.Click, clickHandler);
                ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
error: capy-template...
error: The following command exited with error code 1:
/root/anyc/ziglang/zig-linux-x86_64-0.11.0-dev.1580+a5b34a61a/zig build-exe /root/anyc/learn-zig.d/gui/test-gui/src/main.zig -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gtk-3.0 -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng16 -I/usr/include/x86_64-linux-gnu -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lc --cache-dir /root/anyc/learn-zig.d/gui/test-gui/zig-cache --global-cache-dir /root/.cache/zig --name capy-template --pkg-begin capy /root/anyc/learn-zig.d/gui/test-gui/.zigmod/deps/git/github.com/capy-ui/capy/src/main.zig --pkg-begin zigimg /root/anyc/learn-zig.d/gui/test-gui/.zigmod/deps/git/github.com/capy-ui/capy/vendor/zigimg/zigimg.zig --pkg-end --pkg-end --subsystem native --enable-cache 
error: the following build command failed with exit code 1:
/root/anyc/learn-zig.d/gui/test-gui/zig-cache/o/0eb02ad62a6c0d146a56020d57692f96/build /root/anyc/ziglang/zig-linux-x86_64-0.11.0-dev.1580+a5b34a61a/zig /root/anyc/learn-zig.d/gui/test-gui /root/anyc/learn-zig.d/gui/test-gui/zig-cache /root/.cache/zig
```

after some digging I found a missing case `.PropertyChange => data.propertyChangeHandler = cb,` in backend and when wrote it down it working back as normal
![shot](https://user-images.githubusercontent.com/68287637/218448297-c636c286-f200-4eac-bb02-50ee33f1c2d2.jpg)

