### PR TITLE
expose `install` in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const http = @import("deps.zig").imports.apple_pie;
-const install = @import("build_capy.zig").install;
-const installBuild = @import("build_capy.zig").installBuild;
+pub const install = @import("build_capy.zig").install;
+pub const CapyBuildOptions = @import("build_capy.zig").CapyBuildOptions;
 const FileSource = std.build.FileSource;
 
 /// Step used to run a web server


### PR DESCRIPTION
This is all that is required to start using capy with zig's package manager, although not completely *correct* (it doesn't really use modules like dependencies are supposed to). But it works.

Using the official package manager you use

```zig
const capy = @import("root").dependencies.imports.capy;

...

try capy.install(exe, .{});
```

instead of the following with zigmod

```zig
try deps.imports.capy.install(exe, .{});
```

This doesn't change anything with zigmod, so that should still be functional.