### PR TITLE
Update to zig master (Request#do -> Request#wait)

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -79,12 +79,12 @@ pub usingnamespace if (@hasDecl(backend, "Http")) struct {
         pub const Reader = std.io.Reader(*HttpResponse, ReadError, read);
 
         pub fn isReady(self: *HttpResponse) bool {
-            self.request.do() catch return true;
+            self.request.wait() catch return true;
             return true;
         }
 
         pub fn checkError(self: *HttpResponse) !void {
-            try self.request.do();
+            try self.request.wait();
             // if (self.response.status_code != .success_ok) {
             //     return error.FailedRequest;
             // }


### PR DESCRIPTION
Hey,

in https://github.com/ziglang/zig/pull/15445 `Request#do` has been renamed to `Request#wait`, which causes Capy to not build anymore with the latest zig master version (at least it prevented me from using `capy.Image`). Hence, this PR reflects the upstream changes.
I've tested the changes with the latest master version: [zig-0.11.0-dev.2868+1a455b2dd.tar.xz](https://ziglang.org/builds/zig-0.11.0-dev.2868+1a455b2dd.tar.xz).

Cheers