### PR TITLE
Added menubar to win32 backend

### DIFF
--- a/src/backends/win32/backend.zig
+++ b/src/backends/win32/backend.zig
@@ -402,11 +402,15 @@ pub fn Events(comptime T: type) type {
                     // For menubar item events, HIWORD(wp) and lp are set to 0.
                     else if (code == 0) {
                         const data = getEventUserData(hwnd);
-                        const window: *Window = @ptrFromInt(data.classUserdata);
+                        const window_ptr: ?*Window = @ptrFromInt(data.classUserdata);
                         const id: u16 = @intCast(wp & 0xFFFF);
 
-                        if (window.menu_item_callbacks.items[id]) |callback| {
-                            callback();
+                        if (window_ptr) |window| {
+                            if (id < window.menu_item_callbacks.items.len) {
+                                if (window.menu_item_callbacks.items[id]) |callback| {
+                                    callback();
+                                }
+                            }
                         }
                     }
                 },

--- a/src/backends/win32/backend.zig
+++ b/src/backends/win32/backend.zig
@@ -328,9 +328,6 @@ pub const Window = struct {
         } else {
             self.menu_item_callbacks.clearAndFree();
         }
-
-        // Ensure menu item callbacks can be accessed during event processing.
-        getEventUserData(self.hwnd).classUserdata = @intFromPtr(self);
     }
 
     pub fn setSourceDpi(self: *Window, dpi: u32) void {
@@ -402,7 +399,7 @@ pub fn Events(comptime T: type) type {
                     // For menubar item events, HIWORD(wp) and lp are set to 0.
                     else if (code == 0) {
                         const data = getEventUserData(hwnd);
-                        const window_ptr: ?*Window = @ptrFromInt(data.classUserdata);
+                        const window_ptr: ?*Window = @ptrCast(@alignCast(data.peerPtr));
                         const id: u16 = @intCast(wp & 0xFFFF);
 
                         if (window_ptr) |window| {


### PR DESCRIPTION
Menu Bar added to win32 backend. Concerned about critical error handling (e.g. failure to allocate necessary memory) due to `setMenuBar` no error set interface.

![image](https://github.com/capy-ui/capy/assets/117967760/4e2e0aa7-cf52-43de-9741-b302aa8cb430)
