### PR TITLE
An attempt to update the library to 0.12.0

### DIFF
--- a/android/Sdk.zig
+++ b/android/Sdk.zig
@@ -741,7 +741,7 @@ const CreateResourceDirectory = struct {
 
     fn make(step: *Step, progress: *std.Progress.Node) !void {
         _ = progress;
-        const self = @fieldParentPtr(Self, "step", step);
+        const self: *Self = @fieldParentPtr("step", step);
 
         // if (std.fs.path.dirname(strings_xml)) |dir| {
         //     std.fs.cwd().makePath(dir) catch unreachable;
@@ -1199,7 +1199,7 @@ const BuildOptionStep = struct {
 
     fn make(step: *Step, progress: *std.Progress.Node) !void {
         _ = progress;
-        const self = @fieldParentPtr(Self, "step", step);
+        const self: *Self = @fieldParentPtr("step", step);
 
         var cacher = createCacheBuilder(self.builder);
         cacher.addBytes(self.file_content.items);

--- a/android/build/auto-detect.zig
+++ b/android/build/auto-detect.zig
@@ -367,7 +367,7 @@ pub fn findUserConfig(b: *Builder, versions: Sdk.ToolchainVersions) !UserConfig 
             print("\n", .{});
         }
 
-        std.os.exit(1);
+        std.process.exit(1);
     }
 
     if (config_dirty) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.12.0-dev.2063+804cee3b9",
     .dependencies = .{
         .@"zig-objc" = .{
-            .url = "https://github.com/mitchellh/zig-objc/archive/f6ed382b6db296626a9b56dadcf9d7e4fcba71d3.tar.gz",
-            .hash = "1220c94dbcdf5a799ce2b1571978ff3c97bab1341fe329084fcc3c06e5d6375469b9",
+            .url = "https://github.com/mitchellh/zig-objc/archive/9e2174ed9b5a2c11bf1779cf6c819260c8091888.tar.gz",
+            .hash = "1220014cd3774aa0b18320e6527ed7b3270412c70958ab16a3c55070ffb7f2042f87",
         },
         .macos_sdk = .{
             .url = "https://github.com/mitchellh/zig-build-macos-sdk/archive/4186e9fd445d12041651abe59ea5f396499b0844.tar.gz",

--- a/build_capy.zig
+++ b/build_capy.zig
@@ -66,7 +66,7 @@ const WebServerStep = struct {
         // There's no progress to report on.
         _ = prog_node;
 
-        const self = @fieldParentPtr(WebServerStep, "step", step);
+        const self: *WebServerStep = @fieldParentPtr("step", step);
         const allocator = step.owner.allocator;
         _ = allocator;
 

--- a/src/backends/macos/backend.zig
+++ b/src/backends/macos/backend.zig
@@ -168,12 +168,12 @@ pub const Window = struct {
 
     pub fn show(self: *Window) void {
         self.peer.msgSend(void, "makeKeyAndOrderFront:", .{self.peer.value});
-        _ = activeWindows.fetchAdd(1, .Release);
+        _ = activeWindows.fetchAdd(1, .release);
     }
 
     pub fn close(self: *Window) void {
         self.peer.msgSend(void, "close", .{});
-        _ = activeWindows.fetchSub(1, .Release);
+        _ = activeWindows.fetchSub(1, .release);
     }
 };
 
@@ -261,5 +261,5 @@ pub fn runStep(step: shared.EventLoopStep) bool {
         app.msgSend(void, "sendEvent:", .{event});
         // app.msgSend(void, "updateWindows", .{});
     }
-    return activeWindows.load(.Acquire) != 0;
+    return activeWindows.load(.acquire) != 0;
 }

--- a/src/containers.zig
+++ b/src/containers.zig
@@ -445,9 +445,9 @@ pub const Container = struct {
     /// It shouldn't need to be called as all functions that affect a child's position should also
     /// trigger a relayout. If it doesn't please [file an issue](https://github.com/capy-ui/capy/issues).
     pub fn relayout(self: *Container) void {
-        if (self.relayouting.load(.SeqCst) == true) return;
+        if (self.relayouting.load(.seq_cst) == true) return;
         if (self.peer) |peer| {
-            self.relayouting.store(true, .SeqCst);
+            self.relayouting.store(true, .seq_cst);
             const callbacks = Callbacks{
                 .userdata = @intFromPtr(&peer),
                 .moveResize = moveResize,
@@ -468,7 +468,7 @@ pub const Container = struct {
             }
 
             self.layout(callbacks, tempItems.items);
-            self.relayouting.store(false, .SeqCst);
+            self.relayouting.store(false, .seq_cst);
         }
     }
 

--- a/src/data.zig
+++ b/src/data.zig
@@ -430,9 +430,9 @@ pub fn Atom(comptime T: type) type {
             // If the old value was false, it returns null, which is what we want.
             // Otherwise, it returns the old value, but since the only value other than false is true,
             // we're not interested in the result.
-            if ((if (@hasDecl(atomicValue(bool), "cmpxchgStrong")) self.bindLock.cmpxchgStrong(false, true, .SeqCst, .SeqCst) else self.bindLock.cmpxchg(true, false, true, .SeqCst, .SeqCst) // support zig 0.11 as well as current master
+            if ((if (@hasDecl(atomicValue(bool), "cmpxchgStrong")) self.bindLock.cmpxchgStrong(false, true, .seq_cst, .seq_cst) else self.bindLock.cmpxchg(true, false, true, .SeqCst, .SeqCst) // support zig 0.11 as well as current master
             ) == null) {
-                defer self.bindLock.store(false, .SeqCst);
+                defer self.bindLock.store(false, .seq_cst);
 
                 {
                     if (options.locking) self.lock.lock();

--- a/src/internal.zig
+++ b/src/internal.zig
@@ -102,7 +102,7 @@ pub fn Widgeting(comptime T: type) type {
 
         /// Increase the number of references to this component.
         pub fn ref(self: *T) void {
-            _ = self.widget_data.refcount.fetchAdd(1, .Monotonic);
+            _ = self.widget_data.refcount.fetchAdd(1, .monotonic);
         }
 
         /// Decrease the number of references to this component, that is tell Capy
@@ -111,8 +111,8 @@ pub fn Widgeting(comptime T: type) type {
         /// This is why this function must only be called after you stopped using a pointer
         /// to the component, as using the pointer after unref() may cause a Use-After-Free.
         pub fn unref(self: *T) void {
-            std.debug.assert(self.widget_data.refcount.load(.Monotonic) != 0);
-            if (self.widget_data.refcount.fetchSub(1, .AcqRel) == 1) {
+            std.debug.assert(self.widget_data.refcount.load(.monotonic) != 0);
+            if (self.widget_data.refcount.fetchSub(1, .acq_rel) == 1) {
                 self.deinit();
             }
         }


### PR DESCRIPTION
This pr makes simple changes to make the library able to run on 0.12.0(all credit to the changelog and the compiler), also it updates zig-objc to the latest version as a side effect.

Only tested on macos `test-backend` example.