### PR TITLE
example: calculator @memcpy didn't accept args with unequal lengths

### DIFF
--- a/examples/calculator.zig
+++ b/examples/calculator.zig
@@ -17,7 +17,7 @@ pub fn pressedKey(button_: *anyopaque) !void {
 
     // Concat the computation label with the first character of the button's label
     var larger = try allocator.alloc(u8, labelText.len + 1); // allocate a string one character longer than labelText
-    @memcpy(larger, labelText); // copy labelText's contents to the newly allocated string
+    @memcpy(larger[0..labelText.len], labelText); // copy labelText's contents to the newly allocated string
     larger[labelText.len] = buttonLabel[0]; // finally, set the last letter
 
     computationLabel.setText(larger); // and now we can put that as our new computation label text


### PR DESCRIPTION
the calculator example was crashing
fixed it

cute thing btw get ios up and running and maybe u can defeat the flutter and react native bloats

os: win10
zig version : 0.12.0-dev.3180+83e578a18